### PR TITLE
Update prepackaged configmaps to specify broker correctly

### DIFF
--- a/src/main/knative/deploy.yaml
+++ b/src/main/knative/deploy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudevents-player
 data:
   application.properties: |
-    brokerUrl/mp-rest/url=http://default-broker.default.svc.cluster.local
+    com.redhat.syseng.tools.cloudevents.service.BrokerService/mp-rest/url=http://default-broker
 ---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service

--- a/src/main/knative/deploy_native.yaml
+++ b/src/main/knative/deploy_native.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudevents-player
 data:
   application.properties: |
-    brokerUrl/mp-rest/url=default-broker.default.svc.cluster.local
+    com.redhat.syseng.tools.cloudevents.service.BrokerService/mp-rest/url=http://default-broker
 ---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service


### PR DESCRIPTION
I tried running this on a Kubernetes cluster, and got the following error:

```
ERROR [org.jbo.res.res.i18n] (Thread-6) RESTEASY002020: Unhandled asynchronous exception, sending back 500: java.lang.IllegalArgumentException: Unable to determine the proper baseUrl/baseUri. Consider registering using @RegisterRestClient(baseUri="someuri"), or by adding 'com.redhat.syseng.tools.cloudevents.service.BrokerService/mp-rest/url' to your Quarkus configuration
        at io.quarkus.restclient.runtime.RestClientBase.getBaseUrl(RestClientBase.java:54)
        at io.quarkus.restclient.runtime.RestClientBase.create(RestClientBase.java:30)
        at com.redhat.syseng.tools.cloudevents.service.BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.create(BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.zig:32)
        at com.redhat.syseng.tools.cloudevents.service.BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.get(BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.zig:208)
        at com.redhat.syseng.tools.cloudevents.service.BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.get(BrokerService_caab43ccf44fc6be40517dc2588cca3cecae5bcb_Synthetic_Bean.zig:165)
        at io.quarkus.arc.CurrentInjectionPointProvider.get(CurrentInjectionPointProvider.java:50)
        at com.redhat.syseng.tools.cloudevents.service.MessageService_Bean.create(MessageService_Bean.zig:46)
        at com.redhat.syseng.tools.cloudevents.service.MessageService_Bean.create(MessageService_Bean.zig:114)
        at io.quarkus.arc.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:77)
        at io.quarkus.arc.AbstractSharedContext.lambda$new$0(AbstractSharedContext.java:17)
        at io.quarkus.arc.ComputingCache$CacheFunction.lambda$apply$0(ComputingCache.java:99)
        at io.quarkus.arc.LazyValue.get(LazyValue.java:26)
        at io.quarkus.arc.ComputingCache.getValue(ComputingCache.java:41)
        at io.quarkus.arc.AbstractSharedContext.get(AbstractSharedContext.java:23)
        at com.redhat.syseng.tools.cloudevents.service.MessageService_ClientProxy.arc$delegate(MessageService_ClientProxy.zig:253)
        at com.redhat.syseng.tools.cloudevents.service.MessageService_ClientProxy.send(MessageService_ClientProxy.zig:96)
        at com.redhat.syseng.tools.cloudevents.resources.MessageResource.lambda$sendEvent$1(MessageResource.java:58)
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
        at java.lang.Thread.run(Thread.java:748)
```

Additionally, the current Broker configuration doesn't need the full URL path, so you can simply use `http://default-broker` as the URL and have the install work in any namespace.