### PR TITLE
fix: baseUri of broker ingress starts by broker name

### DIFF
--- a/src/main/java/com/github/ruromero/cloudeventsplayer/service/MessageService.java
+++ b/src/main/java/com/github/ruromero/cloudeventsplayer/service/MessageService.java
@@ -71,7 +71,7 @@ public class MessageService {
                 baseUri = URI.create(brokerUri.get());
             } else if (kClient.getMasterUrl() != null) {
                 var namespace = brokerNamespace.orElse(kClient.getNamespace());
-                baseUri = UriBuilder.fromUri("http://broker-ingress.knative-eventing.svc.cluster.local/{namespace}/{broker}").build(namespace, brokerName);
+                baseUri = UriBuilder.fromUri("http://{broker}-ingress.knative-eventing.svc.cluster.local/{namespace}/{broker}").build(brokerName, namespace, brokerName); 
             } else {
                 LOGGER.error("Unable to define the default namespace");
                 throw new IllegalStateException("Unable to define the default namespace. The Kubernetes Client cannot get the masterUrl");


### PR DESCRIPTION
When `BROKER_NAME` is provided instead of `BROKER_URI`, the baseUri generated is:
`http://broker-ingress.knative-eventing.svc.cluster.local/dmartino-kafka/kafka-broker`

But the `.status.address.url` of the broker `kafka-broker` is instead:
`http://kafka-broker-ingress.knative-eventing.svc.cluster.local/dmartino-kafka/kafka-broker`

The first part has to match the `BROKER_NAME` variable